### PR TITLE
use more display for git branch command

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -37,3 +37,5 @@
 [core]
 	excludesfile = $HOME/.gitignore_global
 	autocrlf = input
+[pager]
+	branch = false


### PR DESCRIPTION
Default behavior modified to `less` display in Git 2.16, but having the branch names displayed in terminal output was useful in typing out branch names when switching branches. Setting config to continue using legacy `more` display for this use case