### PR TITLE
Modify 'g p' shortcut to automatically set upstream

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -22,7 +22,7 @@
 	l = log
 	ld = diff --name-only
 	ldm = diff master --name-only
-	p = push origin
+	p = push -u origin
 	pl = pull origin
 	pr = remote prune origin
 	rb = rebase


### PR DESCRIPTION
## Description

Modifies the git alias to better fit typical workflow. Now allows the the `g fp` step for subsequent updates to be faster by no longer needing to specify the branch name.

### Typical Workflow

```
g co master
g pl
g cob [myBranchName]
# make changes to codebase
g p [myBranchName]
# open for code review, receive feedback, update code change

g ah

g fp
# merge to master once build completes
```

## Appendix

### Alternate Workflow

Depending on team working with force pushes to a branch in code review may be frowned upon since the delta between reviews cannot be seen. If updates to the branch before merge to master are requested as separate commits, here's the workflow for pushing and eventually squashing them together.

```
g co master
g pl
g cob [myBranchName]
# make changes to codebase
g p [myBranchName]
# open for code review, receive feedback, update code change

g p [myBranchName]
# code review finished and approved, squashing for clean commit history
g rbi
# modify all commits below first one to 's' for squashing, then combine commit messages

g fp
# merge to master once build completes
```

**Note:** The `rbi` command has an upper limit of 5 additional commits to the branch over master. If more are needed, use the command directly instead:
```
git rebase -i HEAD~[numberOfCommitsToRebaseHere]
```

### Fixing merge conflicts with master
```
g co master
g pl
g co [myBranchName]
g rbm
# resolve merge conflicts with master as needed
```
