### PR TITLE
Add git tag shortcut support

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -19,6 +19,7 @@
 	dm = diff master 
 	f = fetch
 	fp = push origin -f
+	ft = fetch --tags -f -p
 	l = log
 	ld = diff --name-only
 	ldm = diff master --name-only
@@ -32,6 +33,7 @@
 	s = status
 	sh = stash
 	sp = stash pop
+	t = tag
 [color]
 	ui = true
 [core]


### PR DESCRIPTION
Added 2 tag shortcuts to .gitconfig

## Changes

```
ft = fetch --tags -f -p
```
Force and prune tags from local to match remote, will override any conflicting local tag values

```
t = tag
```
Shorthand for a lightweight tag

## Limitations

Annotated tagging can't be supported by shorthand since it requires 2 user input values

More about tagging can be found [here](https://git-scm.com/book/en/v2/Git-Basics-Tagging)