### PR TITLE
remove mongodb

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -78,6 +78,3 @@ brew install sqlite
 
 # more complete version of sql
 brew install mysql
-
-# multiple versions of mongo
-brew install mongodb


### PR DESCRIPTION
MongoDB is no longer available through HomeBrew since license is now non-open source. See https://stackoverflow.com/questions/57856809/installing-mongodb-with-homebrew

Also comments out packages that are bundled with latest MacOS and/or infrequently used by me. Kept as informational if others ever want to use.