### PR TITLE
add commands to ensure Java 8 is installed for development

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -4,6 +4,13 @@ export PATH="/usr/local/bin:$PATH"
 export CLICOLOR=1
 export LSCOLORS=ExFxCxDxBxegedabagacad
 
+# Maven
+export M3_HOME="/usr/local"
+export PATH=$M3_HOME/bin:$PATH
+
+# Java 8
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_281.jdk/Contents/Home
+
 # bash git completion
 if [ -f $(brew --prefix)/etc/bash_completion ]; then
 	. $(brew --prefix)/etc/bash_completion

--- a/.zshrc
+++ b/.zshrc
@@ -10,7 +10,17 @@ DISABLE_AUTO_UPDATE="true"
 # custom plugins
 plugins=(git)
 
+# disable verifying insecure directories
+ZSH_DISABLE_COMPFIX="true"
+
 source $ZSH/oh-my-zsh.sh
+
+# Maven
+export M3_HOME="/usr/local"
+export PATH=$M3_HOME/bin:$PATH
+
+# Java 8
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_281.jdk/Contents/Home
 
 # git autocompletion
 if [ -f $(brew --prefix)/etc/bash_completion.d/git-completion.zsh ]; then

--- a/README.md
+++ b/README.md
@@ -3,38 +3,6 @@
 *DISCLAIMER:* This repo is a compilation of _my_ dotfiles and general setup. If you want to give these a try, fork the repo and review the code BEFORE applying the settings. Remove things you don't understand and use at your own risk.
 
 
-## External installations
-
-Sublime Text ([2](https://www.sublimetext.com/2) or [3](https://www.sublimetext.com/3))
-  - good cross platform text editor with plenty of plugins for quick development ([package manager installation](https://packagecontrol.io/installation))
-    - Git (blame): https://packagecontrol.io/packages/Git
-    - JSON (pretty print): https://packagecontrol.io/packages/Pretty%20JSON
-  - _Nice to have:_ launch via command line by following the instructions in the following links
-    - Sublime Text 2: https://www.sublimetext.com/docs/2/osx_command_line.html
-    - Sublime Text 3: https://olivierlacan.com/posts/launch-sublime-text-3-from-the-command-line/
-
-[Docker](https://docs.docker.com/release-notes/)
-  - containerized development environments using a `docker-compose.yml` file in the project repository
-
-### Mac OS X specific installations
-
-iTerm2: https://www.iterm2.com/
-  - offers more features (e.g. split screen) than MacOS Terminal
-
-Alfred: https://www.alfredapp.com
-  - alternative quick search that allows for custom URL shortcuts (i.e. JIRA ticket quick query)
-
-![Alfred Example Screenshot](https://github.com/coreen/dotfiles/blob/master/Alfred_Example.png)
-
-### Language specific installations
-
-IntelliJ: https://www.jetbrains.com/idea/download/
-  - Java IDE with nice search and class navigation capabilities
-  - import `./intellij/settings.zip` file for a MacOS/Eclipse custom keybinding
-    - Cmd-Shift-O for opening file by classname (MacOS)
-    - Ctrl-H for keyword search (Eclipse)
-    - Avoid star imports for files, explicit preferred
-
 ## Usage
 
 Copy the dotfiles to your `$HOME` directory
@@ -55,3 +23,39 @@ Initial setup defaults to `bash` shell, if you would like to use `zsh` additiona
 ```
 ./zsh-setup.sh
 ```
+
+## External installations
+
+Docker: https://docs.docker.com/release-notes/
+  - containerized development environments using a `docker-compose.yml` file in the project repository
+
+Sublime Text ([2](https://www.sublimetext.com/2) or [3](https://www.sublimetext.com/3))
+  - good cross platform text editor with plenty of plugins for quick development ([package manager installation](https://packagecontrol.io/installation))
+    - Git (blame): https://packagecontrol.io/packages/Git
+    - JSON (pretty print): https://packagecontrol.io/packages/Pretty%20JSON
+  - _Nice to have:_ launch via command line by following the instructions in the following links
+    - Sublime Text 2: https://www.sublimetext.com/docs/2/osx_command_line.html
+    - Sublime Text 3: https://olivierlacan.com/posts/launch-sublime-text-3-from-the-command-line/
+
+### Language specific installations
+
+Java 8: https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html
+  - requires `JAVA_HOME` to be setup based on downloaded version
+
+IntelliJ: https://www.jetbrains.com/idea/download/
+  - Java IDE with nice search and class navigation capabilities
+  - import `./intellij/settings.zip` file for a MacOS/Eclipse custom keybinding
+    - Cmd-Shift-O for opening file by classname (MacOS)
+    - Ctrl-H for keyword search (Eclipse)
+    - Avoid star imports for files, explicit preferred
+
+### Mac OS X specific installations
+
+iTerm2: https://www.iterm2.com/
+  - offers more features (e.g. split screen) than MacOS Terminal
+
+Alfred: https://www.alfredapp.com
+  - alternative quick search that allows for custom URL shortcuts (i.e. JIRA ticket quick query)
+
+![Alfred Example Screenshot](https://github.com/coreen/dotfiles/blob/master/Alfred_Example.png)
+

--- a/brew.sh
+++ b/brew.sh
@@ -55,12 +55,6 @@ brew install screen
 # newer codebase with added features
 brew install tmux
 
-### JAVA
-
-# Java 8, verify with `javac -version`
-brew install openjdk@8
-sudo ln -sfn /usr/local/opt/openjdk@8/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-8.jdk # override MacOS default
-
 ### BUILDERS
 
 # code compilation

--- a/brew.sh
+++ b/brew.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Useful Homebrew packages
+### Useful Homebrew packages
 
 # TAB autocomplete, requires initialization in .bash_profile or .zshrc
 brew install bash-completion
@@ -55,6 +55,12 @@ brew install screen
 # newer codebase with added features
 brew install tmux
 
+### JAVA
+
+# Java 8, verify with `javac -version`
+brew install openjdk@8
+sudo ln -sfn /usr/local/opt/openjdk@8/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-8.jdk # override MacOS default
+
 ### BUILDERS
 
 # code compilation
@@ -71,7 +77,7 @@ brew install node
 # newer package manager
 brew install yarn
 
-# STORES
+### STORES
 
 # basic version of sql
 brew install sqlite


### PR DESCRIPTION
Verified below
```
$ javac -version
javac 1.8.0_282
```

Java installation before `maven` dependency since Maven will install and link `openjdk` via Homebrew as a dependency if it doesn't already exist. If there are multiple dependencies detected, Homebrew will download but not link the dependency for use.

===

Remember to open a new terminal after running `brew.sh` to see the changes